### PR TITLE
AdminShop display edits

### DIFF
--- a/src/main/java/de/craftlancer/clstuff/adminshop/AdminShopCommandHandler.java
+++ b/src/main/java/de/craftlancer/clstuff/adminshop/AdminShopCommandHandler.java
@@ -1,11 +1,10 @@
 package de.craftlancer.clstuff.adminshop;
 
+import de.craftlancer.core.command.CommandHandler;
 import org.bukkit.plugin.Plugin;
 
-import de.craftlancer.core.command.CommandHandler;
-
 public class AdminShopCommandHandler extends CommandHandler {
-
+    
     public AdminShopCommandHandler(Plugin plugin, AdminShopManager manager) {
         super(plugin);
         
@@ -13,5 +12,6 @@ public class AdminShopCommandHandler extends CommandHandler {
         registerSubCommand("remove", new AdminShopRemoveCommand(plugin));
         registerSubCommand("setbroadcast", new AdminShopSetBroadcastCommand(plugin));
         registerSubCommand("defaultbroadcast", new AdminShopDefaultBroadcastCommand(plugin, manager));
+        registerSubCommand("setDisplayItem", new AdminShopSetDisplayItemCommand(plugin, manager));
     }
 }

--- a/src/main/java/de/craftlancer/clstuff/adminshop/AdminShopDisplayItem.java
+++ b/src/main/java/de/craftlancer/clstuff/adminshop/AdminShopDisplayItem.java
@@ -1,0 +1,72 @@
+package de.craftlancer.clstuff.adminshop;
+
+import de.craftlancer.clstuff.CLStuff;
+import de.craftlancer.core.Utils;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Item;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.util.Vector;
+
+public class AdminShopDisplayItem {
+    public static final String DISPLAY_ITEM_METADATA = "adminshopDisplayItem";
+    
+    private Location spawnLocation;
+    private World world;
+    
+    private ItemStack displayItem;
+    private Item item;
+    
+    public AdminShopDisplayItem(AdminShop shop) {
+        this.world = shop.getLocation().getWorld();
+        this.spawnLocation = shop.getLocation().clone().add(0.5, 1, 0.5);
+    }
+    
+    public boolean tick() {
+        if (displayItem == null || !Utils.isChunkLoaded(spawnLocation))
+            return false;
+        
+        if (item == null || !item.isValid()) {
+            item = world.dropItem(spawnLocation, displayItem);
+            item.setInvulnerable(true);
+            item.setMetadata(DISPLAY_ITEM_METADATA, new FixedMetadataValue(CLStuff.getInstance(), 0));
+        }
+        
+        item.setVelocity(new Vector().zero());
+        
+        return true;
+    }
+    
+    public void remove() {
+        if (item == null)
+            return;
+        
+        item.remove();
+    }
+    
+    public void setItemStack(ItemStack item) {
+        remove();
+        
+        if (item == null)
+            this.displayItem = null;
+        else {
+            ItemStack tmp = item.clone();
+            ItemMeta meta = tmp.getItemMeta();
+            meta.setDisplayName(ChatColor.DARK_GRAY + "AdminShopDisplayItem");
+            
+            tmp.setItemMeta(meta);
+            tmp.setAmount(1);
+            
+            this.displayItem = tmp;
+            
+            tick();
+        }
+    }
+    
+    public Item getItem() {
+        return item;
+    }
+}

--- a/src/main/java/de/craftlancer/clstuff/adminshop/AdminShopSetDisplayItemCommand.java
+++ b/src/main/java/de/craftlancer/clstuff/adminshop/AdminShopSetDisplayItemCommand.java
@@ -1,0 +1,74 @@
+package de.craftlancer.clstuff.adminshop;
+
+import de.craftlancer.core.command.SubCommand;
+import org.bukkit.block.Block;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Collections;
+import java.util.List;
+
+public class AdminShopSetDisplayItemCommand extends SubCommand {
+    
+    private AdminShopManager manager;
+    
+    public AdminShopSetDisplayItemCommand(Plugin plugin, AdminShopManager manager) {
+        super("clstuff.adminshop", plugin, false);
+        
+        this.manager = manager;
+    }
+    
+    @Override
+    protected List<String> onTabComplete(CommandSender sender, String[] args) {
+        if (args.length == 2)
+            return Collections.singletonList("<row>");
+        
+        return Collections.emptyList();
+    }
+    
+    @Override
+    protected String execute(CommandSender sender, Command cmd, String label, String[] args) {
+        if (!checkSender(sender))
+            return "You're not allowed to run this command.";
+        
+        Player p = (Player) sender;
+        Block b = p.getTargetBlock(null, 5);
+        AdminShop shop = manager.getShop(b.getLocation());
+        ItemStack item = p.getInventory().getItemInMainHand();
+        
+        if (shop == null)
+            return "You must look at an AdminShop.";
+        
+        if (args.length < 2)
+            return "You must enter a row.";
+        
+        if (item.getType().isAir())
+            return "You must hold an item.";
+        
+        int i;
+        try {
+            i = Integer.parseInt(args[1]);
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            return "You must enter a row that is between 1 and 4 (inclusive)";
+        }
+        
+        if (i < 1 || i > 4)
+            return "You must enter a row that is between 1 and 4 (inclusive)";
+        
+        shop.getDisplayItems()[i - 1] = item.clone();
+        shop.createMenu();
+        
+        return "Display item set.";
+    }
+    
+    @Override
+    public void help(CommandSender sender) {
+        // TODO Auto-generated method stub
+        
+    }
+    
+}


### PR DESCRIPTION
- Added `/adminshop setDisplayItem <row>` that allows an admin to set an item to be displayed per row in an adminshop.
- In the gui, the player can click the output item to have whatever item the admin sets at that row be displayed above the shop using similar mechanics to QuickShop and the replicator.
- Made it so admins have to sneak + click to open admin editor, instead of it opening instead of a normal player menu.